### PR TITLE
Add conditional  static_assert()

### DIFF
--- a/thread_pool/fixed_function.hpp
+++ b/thread_pool/fixed_function.hpp
@@ -40,8 +40,11 @@ public:
     {
         typedef typename std::remove_reference<FUNC>::type unref_type;
 
+#if THREAD_POOL_FIXED_FUNCTION_SIZE_CONSTRAINT
         static_assert(sizeof(unref_type) < STORAGE_SIZE,
                       "functional object doesn't fit into internal storage");
+#endif
+        
         static_assert(std::is_move_constructible<unref_type>::value, "Should be of movable type");
 
         m_method_ptr = [](void *object_ptr, func_ptr_type, ARGS... args) -> R {


### PR DESCRIPTION
This seems to be a self imposed design constraint as optimization, and it doesn't allow the sample applications to build.  Making this optional for now via `#ifdef THREAD_POOL_FIXED_FUNCTION_SIZE_CONSTRAINT`.  Perhaps this can be configured by the user's code.

![static_assert_error](https://cloud.githubusercontent.com/assets/554720/12785056/8297b2a6-ca58-11e5-8e79-ee5ec64944e0.jpg)
